### PR TITLE
change url of gitmodule to https (fix #6)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party/ros2/ros_tcp_endpoint"]
 	path = third-party/ros2/ros_tcp_endpoint
-	url = git@github.com:Unity-Technologies/ROS-TCP-Endpoint.git
+	url = https://github.com/Unity-Technologies/ROS-TCP-Endpoint.git


### PR DESCRIPTION
If you have already cloned this repository, please do `git submodule sync` to follow this change.