### PR TITLE
pull and use docker image published on Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,24 @@ $ bash utils/install-docker.bash
 
 ## シミュレータの導入手順
 
-### Dockerイメージの作成
+### Dockerイメージの展開
+
+シミュレータの実行環境は，ビルド済みのDocker imageをDocker Hubにて公開しています．
+
+https://hub.docker.com/r/toppersjp/hakoniwa-ros2sim
+
+現在の最新版は **v1.0.0** です．
+「[バージョン情報・更新履歴](/appendix/version.md)」も参照してください（バージョン番号は[Git/GitHubのtag/release](https://github.com/toppers/hakoniwa-ros2sim/releases)および[Docker Hubのtag番号](https://hub.docker.com/r/toppersjp/hakoniwa-ros2sim/tags)に対応しています）
+
+次のコマンドを実行してください．Dockerを立ち上げて，imageのpullと展開を行います．
+
+```
+$ sudo service docker start
+$ cd ros2/docker
+$ bash pull-image.bash
+```
+
+\[開発者向け情報\] Dockerイメージの作成
 
 #### Windows環境
 

--- a/appendix/version.md
+++ b/appendix/version.md
@@ -1,0 +1,24 @@
+# バージョン情報・更新履歴
+
+## バージョン番号の付与規則
+
+`vX.Y.Z` のようにバージョン番号を付与します．この番号は `ros2/docker/image_name.txt` でも管理されています．また，[Git/GitHubのtag/release](https://github.com/toppers/hakoniwa-ros2sim/releases)および[Docker Hubのtag番号](https://hub.docker.com/r/toppersjp/hakoniwa-ros2sim/tags)に対応しています．
+
+各バージョン番号の更新は，次の規則で行います．
+
+- Major version (`X`): 
+    - 箱庭コア技術の新機能の導入
+    - 使用方法の大きな変更　など
+- Minor version (`Y`): 
+    - 箱庭アセット技術（各リポジトリ）の更新
+    - 大幅な機能の修正
+    - シミュレータ本体の新たな機能の追加　など
+- Revison (`Z`): 
+    - 軽微な機能の修正・バグの対応
+    - ドキュメントの更新　など
+
+## 更新履歴
+
+### v1.0.0 @ 2022/04/23
+
+- 最初のリリース

--- a/ros2/docker/attach-linux.bash
+++ b/ros2/docker/attach-linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim:v1.0.0
+DOCKER_IMAGE=`cat image_name.txt`
 DOCKER_ID=`docker ps | grep "${DOCKER_IMAGE}" | awk '{print $1}'`
 
 docker exec -it ${DOCKER_ID} /bin/bash

--- a/ros2/docker/attach.bash
+++ b/ros2/docker/attach.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim:v1.0.0
+DOCKER_IMAGE=`cat image_name.txt`
 DOCKER_ID=`sudo docker ps | grep "${DOCKER_IMAGE}" | awk '{print $1}'`
 
 sudo docker exec -it ${DOCKER_ID} /bin/bash

--- a/ros2/docker/create-image-linux.bash
+++ b/ros2/docker/create-image-linux.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim
+DOCKER_IMAGE=`cat image_name.txt`
 DOCKER_FILE=Dockerfile
-DOCKER_TAG=v1.0.0
-docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f ${DOCKER_FILE} .
+docker build -t ${DOCKER_IMAGE} -f ${DOCKER_FILE} .
 

--- a/ros2/docker/create-image.bash
+++ b/ros2/docker/create-image.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim
+DOCKER_IMAGE=`cat image_name.txt`
 DOCKER_FILE=Dockerfile
-DOCKER_TAG=v1.0.0
-sudo docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f ${DOCKER_FILE} .
+sudo docker build -t ${DOCKER_IMAGE} -f ${DOCKER_FILE} .
 

--- a/ros2/docker/image_name.txt
+++ b/ros2/docker/image_name.txt
@@ -1,0 +1,1 @@
+toppersjp/hakoniwa-ros2sim:v1.0.0

--- a/ros2/docker/pull-image.bash
+++ b/ros2/docker/pull-image.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DOCKER_IMAGE=`cat image_name.txt`
+
+sudo service docker start
+sudo docker pull ${DOCKER_IMAGE}

--- a/ros2/docker/run-linux.bash
+++ b/ros2/docker/run-linux.bash
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim
-
 HAKONIWA_TOP_DIR=$(cd ../.. && pwd)
-DOCKER_IMAGE=${DOCKER_IMAGE}:v1.0.0
+DOCKER_IMAGE=`cat image_name.txt`
 
 docker run -v ${HAKONIWA_TOP_DIR}:/root/workspace/hakoniwa-ros-samples \
 		-e CORE_IPADDR=127.0.0.1 \

--- a/ros2/docker/run-mac.bash
+++ b/ros2/docker/run-mac.bash
@@ -6,10 +6,9 @@ then
 fi
 ETHER=${1}
 IPADDR=`ifconfig | grep -A1 ${ETHER} | grep netmask | awk '{print $2}'`
-DOCKER_IMAGE=hakoniwa-ros2sim
 
 HAKONIWA_TOP_DIR=$(cd ../.. && pwd)
-DOCKER_IMAGE=${DOCKER_IMAGE}:v1.0.0
+DOCKER_IMAGE=`cat image_name.txt`
 
 sudo docker ps > /dev/null
 if [ $? -ne 0 ]

--- a/ros2/docker/run.bash
+++ b/ros2/docker/run.bash
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-DOCKER_IMAGE=hakoniwa-ros2sim
-
 HAKONIWA_TOP_DIR=$(cd ../.. && pwd)
-DOCKER_IMAGE=${DOCKER_IMAGE}:v1.0.0
+DOCKER_IMAGE=`cat image_name.txt`
 
 sudo docker ps > /dev/null
 if [ $? -ne 0 ]


### PR DESCRIPTION
Published image on Docker Hub
https://hub.docker.com/r/toppersjp/hakoniwa-ros2sim

---
Docker Hub にビルド済みのイメージを公開し，これを pull して利用してもらうように変更しました．