### PR TITLE
add hakoniwa proxy for ros2

### DIFF
--- a/ros2/workspace/rosnode_run.bash
+++ b/ros2/workspace/rosnode_run.bash
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+source /opt/ros/foxy/setup.bash
+source install/setup.bash
+
+if [ $# -ne 2 ]
+then
+	echo "Usage: $0 <pkgname> <RoboName>"
+	exit 1
+fi
+
+ROSNODE_NAME=${1}_node
+ROBO_NAME=${2}
+IS_EXIT="FALSE"
+ROSNODE_PID="NONE"
+signal_handler () {
+	if [ ${ROSNODE_PID} = "NONE" ]
+	then
+		echo "NONE"
+	else
+		kill -s TERM ${ROSNODE_PID}
+		sleep 1
+		#ps aux | grep ${ROSNODE_NAME} | grep -v grep | awk '{print $2}' | xargs kill -s TERM
+		#sleep 1
+		echo "Terminated!! ${ROSNODE_PID}"
+		IS_EXIT="TRUE"
+	fi
+}
+
+trap signal_handler INT TERM
+
+#/root/workspace/hakoniwa-ros-sim/ros2/workspace/tmp.bash &
+/opt/ros/foxy/bin/ros2 run ${1} ${ROSNODE_NAME} ${ROBO_NAME} &
+ROSNODE_PID=$!
+echo "ROSNODE_PID=$ROSNODE_PID"
+
+
+while [ 1 ]
+do
+	if [ ${IS_EXIT} = "TRUE" ]
+	then
+		exit 0
+	fi
+	sleep 1
+done

--- a/settings/tb3/template_custom.json
+++ b/settings/tb3/template_custom.json
@@ -1,0 +1,22 @@
+{
+  "proxies": [
+    {
+      "robot_name": "TB3RoboModel",
+      "proxy_type": "ros",
+      "proxy_sync": {
+      	"pkg_name": "tb3",
+      	"node_name": "TB3RoboModel",
+        "ipaddr": "172.26.53.244",
+        "tx_udp_portno": 54001,
+        "rx_udp_portno": 54002,
+        "interval_time_msec": 100,
+        "target_bin_path": "./rosnode_run.bash",
+        "target_exec_dir": ".",
+        "target_options": [
+			"tb3",
+			"TB3RoboModel"
+        ]
+      }
+    }
+  ]
+}

--- a/utils/core_config/all.bash
+++ b/utils/core_config/all.bash
@@ -30,7 +30,7 @@ ROS_TOPIC_FILE_PATH=../../../${SETTING_FOLDER}/RosTopics.json
 OUT_DIR=${UNITY_PRJ_DIR}
 ROS_MSG_LIST=${SETTING_FOLDER}/ros_msgs.txt
 
-CUSTOM_FILE_PATH=${SETTING_FOLDER}/custom.json${SETTING_FOLDER}
+CUSTOM_FILE_PATH=${SETTING_FOLDER}/custom.json
 
 WORLD_SCALE=$(cat "${SETTING_FOLDER}"/world_scale.txt)
 
@@ -78,15 +78,15 @@ then
 	echo "####Creating proxy_param"
 	python2 utils/core_config/create_proxy_param.py  		"${CUSTOM_FILE_PATH}" 	"${CORE_IPADDR}"	"${ROS_VERSION}"/workspace
 
-	echo "####Downloading Hakoniwa.dll"
-	wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.0/Hakoniwa.dll
-	mv Hakoniwa.dll "${UNITY_PRJ_DIR}"/Assets/Plugin/
+	#echo "####Downloading Hakoniwa.dll"
+	#wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.0/Hakoniwa.dll
+	#mv Hakoniwa.dll "${UNITY_PRJ_DIR}"/Assets/Plugin/
 
 	echo "####Downloading MiconPdu.dll"
-	wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.0/MiconPdu.dll
+	wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.1/MiconPdu.dll
 	mv MiconPdu.dll "${UNITY_PRJ_DIR}"/
 
 	echo "####Downloading HakoniwaSimTime.json"
-	wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.0/HakoniwaSimTime.json
+	wget https://github.com/toppers/hakoniwa-core/releases/download/v1.0.1/HakoniwaSimTime.json
 	mv HakoniwaSimTime.json "${UNITY_PRJ_DIR}"/
 fi


### PR DESCRIPTION
# 修正概要

ROS2ノードを箱庭プロキシを通して実行できるようにする．
メリット：箱庭シミュレーション操作(開始，停止など)と連携してROS2ノードの実行制御できるようになる
例：
- 箱庭シミュレーション開始と同時に，当該ROS2ノードが起動する
- 箱庭シミュレーション停止と同時に，当該ROS2ノードが停止する

本修正は，既存機能に影響を与えないように，以下の導入手順を実施しないと適用されないようにしています．

# 導入手順

* `settings/tb3/template_custom.json` を `settings/tb3/custom.json` に変名する
* custom.json の以下を変更する
  * robot_name
    * Unityで設定したTB3のロボット名
  * node_name
    * Unityで設定したTB3のロボット名
  * ipaddr
    * 以下の方法で取得したIPアドレス(WSL2/dockerの場合)
      * NETWORK_INTERFACE=$(route | grep '^default' | grep -o '[^ ]*$' | tr -d '\n')
      * IP_ADDR=$(ifconfig "${NETWORK_INTERFACE}" | grep netmask | awk '{print $2}')
  * target_options
    * ２個目の値を，`Unityで設定したTB3のロボット名`　にする
    
# 操作方法

```
$ pwd
/root/workspace/hakoniwa-ros2sim/ros2/workspace

$ bash hako-installba.sh
###Phase3(config): Creating core_config
####Creating core_config
####Creating ros_topic_method
####Creating inside_assets
####Creating pdu_readers
####Creating pdu_writers
####Creating reader_channels
####Creating writer_channels
####Creating pdu_channel_connectors
####Creating unity_ros_params
####Creating pdu_config
####Creating param_world
####Creating tb3_parts
####Creating outside_assets
####Creating udp_methods
####Creating proxy_param
####Downloading MiconPdu.dll
--2022-05-15 08:54:19--  https://github.com/toppers/hakoniwa-core/releases/download/v1.0.1/MiconPdu.dll
Resolving github.com (github.com)... 52.192.72.89, 198.51.44.8, 198.51.45.8, ...
Connecting to github.com (github.com)|52.192.72.89|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/340559655/4e4b36cb-7327-45a5-a4e4-d075f39e9c99?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220515%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220515T085419Z&X-Amz-Expires=300&X-Amz-Signature=30322e838770bc97b5bb298a104438effd43453762680576a9186fe24bc14208&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=340559655&response-content-disposition=attachment%3B%20filename%3DMiconPdu.dll&response-content-type=application%2Foctet-stream [following]
--2022-05-15 08:54:19--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/340559655/4e4b36cb-7327-45a5-a4e4-d075f39e9c99?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220515%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220515T085419Z&X-Amz-Expires=300&X-Amz-Signature=30322e838770bc97b5bb298a104438effd43453762680576a9186fe24bc14208&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=340559655&response-content-disposition=attachment%3B%20filename%3DMiconPdu.dll&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 18944 (18K) [application/octet-stream]
Saving to: ‘MiconPdu.dll’

MiconPdu.dll                  100%[=================================================>]  18.50K  --.-KB/s    in 0.009s

2022-05-15 08:54:20 (1.96 MB/s) - ‘MiconPdu.dll’ saved [18944/18944]

####Downloading HakoniwaSimTime.json
--2022-05-15 08:54:20--  https://github.com/toppers/hakoniwa-core/releases/download/v1.0.1/HakoniwaSimTime.json
Resolving github.com (github.com)... 52.192.72.89, 198.51.44.8, 198.51.45.8, ...
Connecting to github.com (github.com)|52.192.72.89|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/340559655/48508056-ed72-47d4-92cc-aa33136a3b11?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220515%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220515T085420Z&X-Amz-Expires=300&X-Amz-Signature=6680c223f0c0802f8f6548ce6ae15194bbbe768c558e624f6c582cfe836213a5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=340559655&response-content-disposition=attachment%3B%20filename%3DHakoniwaSimTime.json&response-content-type=application%2Foctet-stream [following]
--2022-05-15 08:54:20--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/340559655/48508056-ed72-47d4-92cc-aa33136a3b11?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220515%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220515T085420Z&X-Amz-Expires=300&X-Amz-Signature=6680c223f0c0802f8f6548ce6ae15194bbbe768c558e624f6c582cfe836213a5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=340559655&response-content-disposition=attachment%3B%20filename%3DHakoniwaSimTime.json&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 83 [application/octet-stream]
Saving to: ‘HakoniwaSimTime.json’

HakoniwaSimTime.json          100%[=================================================>]      83  --.-KB/s    in 0s

2022-05-15 08:54:21 (5.65 MB/s) - ‘HakoniwaSimTime.json’ saved [83/83]

###Phase3(json): Success
Model is already installed.
Plugin is already installed.
Resources is already installed.

$ bash ../../utils/hakoniwa_proxy.bash ./TB3RoboModel_proxy_param.json
############ START CONNECT #################
Client Register reply received:
INFO: Register Asset TB3RoboModelProxy success
INFO: Notification Setting success
####THREAD START:
add_option:./rosnode_run.bash
add_option:tb3
add_option:TB3RoboModel
####real_time_sync_tx_thread START:
####real_time_sync_rx_thread START:
```