### PR TITLE
custom.json bug fixed

### DIFF
--- a/settings/tb3/custom.json
+++ b/settings/tb3/custom.json
@@ -16,7 +16,7 @@
           "conv_class_name": "Hakoniwa.PluggableAsset.Communication.Pdu.Raw.RawPduReaderConverter",
           "conv_class_path": "",
           "channel_id": 0,
-          "pdu_size": 1024
+          "pdu_size": 196
         }
       ],
       "rpc_pdu_writers": [
@@ -29,7 +29,9 @@
           "conv_class_name": "Hakoniwa.PluggableAsset.Communication.Pdu.Raw.RawPduWriterConverter",
           "conv_class_path": "",
           "channel_id": 1,
-          "pdu_size": 1024
+          "pdu_size": 248,
+          "write_cycle": 1,
+          "method_type": "UDP"
         }
       ]
     }


### PR DESCRIPTION
[発生現象]
以下の手順で動作確認を進めると、Unity側でエラー発生します。

https://qiita.com/kanetugu2018/items/65a57b6bc4bbab7e43d5


```
DivideByZeroException: Attempted to divide by zero.
Hakoniwa.PluggableAsset.Communication.Method.Rpc.RpcWriter.Flush (Hakoniwa.PluggableAsset.Communication.Pdu.IPduCommData data) (at <4427c912e52547089011706b62c39b7c>:0)
System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state) (at <c2a97e0383e8404c9fc0ae19d58f57f1>:0)
UnityEngine.UnitySynchronizationContext+WorkRequest.Invoke () (at <6afd1274f120405096bc1ad9e2010ba6>:0)
UnityEngine.UnitySynchronizationContext.Exec () (at <6afd1274f120405096bc1ad9e2010ba6>:0)
UnityEngine.UnitySynchronizationContext.ExecuteTasks () (at <6afd1274f120405096bc1ad9e2010ba6>:0)
```

[原因]
custom.jsonのPDUサイズがズレていたのと通信方式が未設定であったことが原因です。

[対応]
custom.jsonを適切に修正した。


