### PR TITLE
IPADDR couldn't get in run.bash.

### DIFF
--- a/docker/run.bash
+++ b/docker/run.bash
@@ -31,7 +31,7 @@ then
 		exit 1
 	fi
 	ETHER=${1}
-	IPADDR=`ifconfig | grep -A1 ${ETHER} | grep netmask | awk '{print $2}'`
+	IPADDR=`ifconfig ${ETHER} | grep netmask | awk '{print $2}'`
 else
 	IPADDR="127.0.0.1"
 fi


### PR DESCRIPTION
ifconfigでinet6が複数ある場合にv4のアドレスが取得できなくばあいがあります。（２、３行しか取得できないので）なります。インターフェース名は引数で与えられるので、ifconfigでインタフェース名を付けることで、該当のネットワーク情報からnetmaskがあるアドレスを取得するように変更しました。